### PR TITLE
Fixes

### DIFF
--- a/src/main/java/com/ordwen/odailyquests/ODailyQuests.java
+++ b/src/main/java/com/ordwen/odailyquests/ODailyQuests.java
@@ -9,6 +9,8 @@ import com.ordwen.odailyquests.commands.completers.PlayerCompleter;
 import com.ordwen.odailyquests.commands.interfaces.InterfacesManager;
 import com.ordwen.odailyquests.commands.interfaces.InventoryClickListener;
 import com.ordwen.odailyquests.configuration.ConfigurationManager;
+import com.ordwen.odailyquests.configuration.essentials.Modes;
+import com.ordwen.odailyquests.configuration.essentials.Temporality;
 import com.ordwen.odailyquests.files.*;
 import com.ordwen.odailyquests.quests.player.progression.ValidateVillagerTradeQuest;
 import com.ordwen.odailyquests.tools.Metrics;
@@ -96,12 +98,12 @@ public final class ODailyQuests extends JavaPlugin {
         interfacesManager.initAllObjects();
 
         /* Load commands */
-        getCommand("quests").setExecutor(new PlayerCommands(configurationFiles));
-        getCommand("questsadmin").setExecutor(new AdminCommands(this));
+        getCommand("dquests").setExecutor(new PlayerCommands(configurationFiles));
+        getCommand("dqadmin").setExecutor(new AdminCommands(this));
 
         /* Load Tab Completers */
-        getCommand("quests").setTabCompleter(new PlayerCompleter());
-        getCommand("questsadmin").setTabCompleter(new AdminCompleter());
+        getCommand("dquests").setTabCompleter(new PlayerCompleter());
+        getCommand("dqadmin").setTabCompleter(new AdminCompleter());
 
         /* Load listeners */
         getServer().getPluginManager().registerEvents(new ValidateVillagerTradeQuest(), this);
@@ -142,7 +144,9 @@ public final class ODailyQuests extends JavaPlugin {
         }
 
         /* Init delayed task to draw new quests */
-        timerTask = new TimerTask(LocalDateTime.now());
+        if (Modes.getTimestampMode() == 1 && Temporality.getTemporalityMode() == 1) {
+            timerTask = new TimerTask(LocalDateTime.now());
+        }
 
         PluginLogger.info(ChatColor.GREEN + "Plugin is started !");
     }
@@ -150,7 +154,7 @@ public final class ODailyQuests extends JavaPlugin {
     @Override
     public void onDisable() {
 
-        timerTask.stop();
+        if (timerTask != null) timerTask.stop();
 
         /* Avoid server/plugin reload errors */
         if (getServer().getOnlinePlayers().size() > 0) {
@@ -173,7 +177,7 @@ public final class ODailyQuests extends JavaPlugin {
             }
         }
 
-        mySqlManager.close();
+        if (mySqlManager != null) mySqlManager.close();
 
         PluginLogger.info(ChatColor.RED + "Plugin is shutting down...");
     }

--- a/src/main/java/com/ordwen/odailyquests/apis/hooks/eco/VaultHook.java
+++ b/src/main/java/com/ordwen/odailyquests/apis/hooks/eco/VaultHook.java
@@ -1,5 +1,6 @@
 package com.ordwen.odailyquests.apis.hooks.eco;
 
+import com.ordwen.odailyquests.tools.PluginLogger;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.RegisteredServiceProvider;
@@ -21,6 +22,7 @@ public class VaultHook {
         if (rsp == null) {
             return false;
         }
+
         econ = rsp.getProvider();
         return econ != null;
     }

--- a/src/main/java/com/ordwen/odailyquests/commands/AdminCommands.java
+++ b/src/main/java/com/ordwen/odailyquests/commands/AdminCommands.java
@@ -19,6 +19,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -32,161 +33,159 @@ public class AdminCommands implements CommandExecutor {
     }
 
     @Override
-    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (command.getName().equalsIgnoreCase("questsadmin")) {
-            if (sender.hasPermission(QuestsPermissions.QUESTS_ADMIN.getPermission())) {
-                if (args.length == 1) {
-                    if ("reload".equals(args[0])) {
-                        oDailyQuests.filesManager.loadAllFiles();
-                        oDailyQuests.configurationManager.loadConfiguration();
+    public boolean onCommand(CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (sender.hasPermission(QuestsPermissions.QUESTS_ADMIN.getPermission())) {
+            if (args.length == 1) {
+                if ("reload".equals(args[0])) {
+                    oDailyQuests.filesManager.loadAllFiles();
+                    oDailyQuests.configurationManager.loadConfiguration();
 
-                        oDailyQuests.interfacesManager.initAllObjects();
-                        LoadQuests.loadCategories();
+                    oDailyQuests.interfacesManager.initAllObjects();
+                    LoadQuests.loadCategories();
 
-                        sender.sendMessage(ChatColor.GREEN + "Plugin successfully reloaded!");
-                    } else {
-                        sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
-                    }
-                } else if (args.length >= 2) {
-                    switch (args[0]) {
-                        case "reset":
-                            if (args.length >= 3 && args[1] != null && args[2] != null) {
-                                switch (args[1]) {
-                                    case "quests":
-                                        if (Bukkit.getPlayerExact(args[2]) != null) {
-                                            int totalAchievedQuests = QuestsManager.getActiveQuests().get(args[2]).getTotalAchievedQuests();
+                    sender.sendMessage(ChatColor.GREEN + "Plugin successfully reloaded!");
+                } else {
+                    sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
+                }
+            } else if (args.length >= 2) {
+                switch (args[0]) {
+                    case "reset":
+                        if (args.length >= 3 && args[1] != null && args[2] != null) {
+                            switch (args[1]) {
+                                case "quests":
+                                    if (Bukkit.getPlayerExact(args[2]) != null) {
+                                        int totalAchievedQuests = QuestsManager.getActiveQuests().get(args[2]).getTotalAchievedQuests();
 
-                                            QuestsManager.getActiveQuests().remove(args[2]);
-                                            LinkedHashMap<Quest, Progression> quests = new LinkedHashMap<>();
-                                            QuestsManager.selectRandomQuests(quests);
+                                        QuestsManager.getActiveQuests().remove(args[2]);
+                                        LinkedHashMap<Quest, Progression> quests = new LinkedHashMap<>();
+                                        QuestsManager.selectRandomQuests(quests);
 
-                                            PlayerQuests playerQuests = new PlayerQuests(System.currentTimeMillis(), quests);
-                                            playerQuests.setTotalAchievedQuests(totalAchievedQuests);
+                                        PlayerQuests playerQuests = new PlayerQuests(System.currentTimeMillis(), quests);
+                                        playerQuests.setTotalAchievedQuests(totalAchievedQuests);
 
-                                            QuestsManager.getActiveQuests().put(args[2], playerQuests);
-                                            QuestsManager.getActiveQuests().get(args[2]).setAchievedQuests(0);
+                                        QuestsManager.getActiveQuests().put(args[2], playerQuests);
+                                        QuestsManager.getActiveQuests().get(args[2]).setAchievedQuests(0);
 
-                                            PluginLogger.info(ChatColor.GREEN + args[2] + ChatColor.YELLOW + " inserted into the array.");
+                                        PluginLogger.info(ChatColor.GREEN + args[2] + ChatColor.YELLOW + " inserted into the array.");
 
-                                            sender.sendMessage(QuestsMessages.QUESTS_RENEWED_ADMIN.toString().replace("%target%", Bukkit.getPlayerExact(args[2]).getName()));
-                                            Bukkit.getPlayerExact(args[2]).sendMessage(QuestsMessages.QUESTS_RENEWED.toString());
-                                        } else sender.sendMessage(QuestsMessages.INVALID_PLAYER.toString());
-                                        break;
-                                    case "total":
-                                        if (Bukkit.getPlayerExact(args[2]) != null) {
-                                            QuestsManager.getActiveQuests().get(args[2]).setTotalAchievedQuests(0);
+                                        sender.sendMessage(QuestsMessages.QUESTS_RENEWED_ADMIN.toString().replace("%target%", Bukkit.getPlayerExact(args[2]).getName()));
+                                        Bukkit.getPlayerExact(args[2]).sendMessage(QuestsMessages.QUESTS_RENEWED.toString());
+                                    } else sender.sendMessage(QuestsMessages.INVALID_PLAYER.toString());
+                                    break;
+                                case "total":
+                                    if (Bukkit.getPlayerExact(args[2]) != null) {
+                                        QuestsManager.getActiveQuests().get(args[2]).setTotalAchievedQuests(0);
 
-                                            sender.sendMessage(QuestsMessages.TOTAL_AMOUNT_RESET_ADMIN.toString().replace("%target%", Bukkit.getPlayerExact(args[2]).getName()));
-                                            Bukkit.getPlayerExact(args[2]).sendMessage(QuestsMessages.TOTAL_AMOUNT_RESET.toString());
-                                        } else sender.sendMessage(QuestsMessages.INVALID_PLAYER.toString());
-                                        break;
-                                    default:
-                                        sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
-                                        break;
-                                }
-                            } else sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
-                            break;
-                        case "show":
-                            if (sender instanceof Player) {
-                                if (Bukkit.getPlayerExact(args[1]) != null) {
-                                    ((Player) sender).openInventory(PlayerQuestsInterface.getPlayerQuestsInterface(args[1]));
-                                } else sender.sendMessage(QuestsMessages.INVALID_PLAYER.toString());
-                            } else sender.sendMessage(QuestsMessages.PLAYER_ONLY.toString());
-                            break;
-                        case "complete":
+                                        sender.sendMessage(QuestsMessages.TOTAL_AMOUNT_RESET_ADMIN.toString().replace("%target%", Bukkit.getPlayerExact(args[2]).getName()));
+                                        Bukkit.getPlayerExact(args[2]).sendMessage(QuestsMessages.TOTAL_AMOUNT_RESET.toString());
+                                    } else sender.sendMessage(QuestsMessages.INVALID_PLAYER.toString());
+                                    break;
+                                default:
+                                    sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
+                                    break;
+                            }
+                        } else sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
+                        break;
+                    case "show":
+                        if (sender instanceof Player) {
                             if (Bukkit.getPlayerExact(args[1]) != null) {
-                                if (args[2] != null && Integer.parseInt(args[2]) >= 1 && Integer.parseInt(args[2]) <= 3) {
-                                    HashMap<Quest, Progression> playerQuests = QuestsManager.getActiveQuests().get(args[1]).getPlayerQuests();
-                                    int index = 0;
-                                    for (Quest quest : playerQuests.keySet()) {
-                                        Progression progression = playerQuests.get(quest);
-                                        if (index == Integer.parseInt(args[2]) - 1) {
-                                            if (!playerQuests.get(quest).isAchieved()) {
-                                                progression.isAchieved = true;
-                                                RewardManager.sendAllRewardItems(quest.getQuestName(), args[1], quest.getReward());
-                                                playerQuests.replace(quest, progression);
-                                                QuestsManager.getActiveQuests().get(args[1]).increaseAchievedQuests(args[1]);
-                                                break;
-                                            } else sender.sendMessage(QuestsMessages.QUEST_ALREADY_ACHIEVED.toString());
-                                        }
-                                        index++;
-                                    }
-                                } else sender.sendMessage(QuestsMessages.INVALID_QUEST_ID.toString());
+                                ((Player) sender).openInventory(PlayerQuestsInterface.getPlayerQuestsInterface(args[1]));
                             } else sender.sendMessage(QuestsMessages.INVALID_PLAYER.toString());
-                            break;
-                        case "holo":
-                            if (sender instanceof Player) {
-                                if (args.length >= 3 && args[1] != null && args[2] != null) {
-                                    if (args[1].equalsIgnoreCase("create")) {
-                                        if (args.length == 4 && args[3] != null) {
-                                            int index;
-                                            try {
-                                                index = Integer.parseInt(args[3]) - 1;
-                                            } catch (Exception e) {
-                                                sender.sendMessage(QuestsMessages.INVALID_QUEST_INDEX.toString());
-                                                return true;
-                                            }
-                                            switch (args[2]) {
-                                                case "global":
-                                                    if (LoadQuests.getGlobalQuests().size() != 0) {
-                                                        HolographicDisplaysHook.createHologram(index,
-                                                                LoadQuests.getGlobalQuests(),
-                                                                ((Player) sender).getPlayer());
-                                                    } else
-                                                        sender.sendMessage(QuestsMessages.HOLO_CATEGORIZED_ENABLED.toString());
-                                                    break;
-                                                case "easy":
-                                                    if (LoadQuests.getEasyQuests().size() != 0) {
-                                                        HolographicDisplaysHook.createHologram(index,
-                                                                LoadQuests.getEasyQuests(),
-                                                                ((Player) sender).getPlayer());
-                                                    } else
-                                                        sender.sendMessage(QuestsMessages.HOLO_CATEGORIZED_DISABLED.toString());
-                                                    break;
-                                                case "medium":
-                                                    if (LoadQuests.getMediumQuests().size() != 0) {
-                                                        HolographicDisplaysHook.createHologram(index,
-                                                                LoadQuests.getMediumQuests(),
-                                                                ((Player) sender).getPlayer());
-                                                    } else
-                                                        sender.sendMessage(QuestsMessages.HOLO_CATEGORIZED_DISABLED.toString());
-                                                    break;
-                                                case "hard":
-                                                    if (LoadQuests.getHardQuests().size() != 0) {
-                                                        HolographicDisplaysHook.createHologram(index,
-                                                                LoadQuests.getHardQuests(),
-                                                                ((Player) sender).getPlayer());
-                                                    } else
-                                                        sender.sendMessage(QuestsMessages.HOLO_CATEGORIZED_DISABLED.toString());
-                                                    break;
-                                                default:
-                                                    sender.sendMessage(QuestsMessages.INVALID_CATEGORY.toString());
-                                                    break;
-                                            }
+                        } else sender.sendMessage(QuestsMessages.PLAYER_ONLY.toString());
+                        break;
+                    case "complete":
+                        if (Bukkit.getPlayerExact(args[1]) != null) {
+                            if (args[2] != null && Integer.parseInt(args[2]) >= 1 && Integer.parseInt(args[2]) <= 3) {
+                                HashMap<Quest, Progression> playerQuests = QuestsManager.getActiveQuests().get(args[1]).getPlayerQuests();
+                                int index = 0;
+                                for (Quest quest : playerQuests.keySet()) {
+                                    Progression progression = playerQuests.get(quest);
+                                    if (index == Integer.parseInt(args[2]) - 1) {
+                                        if (!playerQuests.get(quest).isAchieved()) {
+                                            progression.isAchieved = true;
+                                            RewardManager.sendAllRewardItems(quest.getQuestName(), args[1], quest.getReward());
+                                            playerQuests.replace(quest, progression);
+                                            QuestsManager.getActiveQuests().get(args[1]).increaseAchievedQuests(args[1]);
                                             break;
-                                        } else sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
-                                    } else if (args.length == 3 && args[1].equalsIgnoreCase("delete")) {
+                                        } else sender.sendMessage(QuestsMessages.QUEST_ALREADY_ACHIEVED.toString());
+                                    }
+                                    index++;
+                                }
+                            } else sender.sendMessage(QuestsMessages.INVALID_QUEST_ID.toString());
+                        } else sender.sendMessage(QuestsMessages.INVALID_PLAYER.toString());
+                        break;
+                    case "holo":
+                        if (sender instanceof Player) {
+                            if (args.length >= 3 && args[1] != null && args[2] != null) {
+                                if (args[1].equalsIgnoreCase("create")) {
+                                    if (args.length == 4 && args[3] != null) {
                                         int index;
                                         try {
-                                            index = Integer.parseInt(args[2]);
+                                            index = Integer.parseInt(args[3]) - 1;
                                         } catch (Exception e) {
                                             sender.sendMessage(QuestsMessages.INVALID_QUEST_INDEX.toString());
                                             return true;
                                         }
-                                        if (HologramsManager.deleteHologram(index)) {
-                                            sender.sendMessage(QuestsMessages.HOLO_DELETED.toString());
-                                        } else sender.sendMessage(QuestsMessages.HOLO_INVALID_INDEX.toString());
+                                        switch (args[2]) {
+                                            case "global":
+                                                if (LoadQuests.getGlobalQuests().size() != 0) {
+                                                    HolographicDisplaysHook.createHologram(index,
+                                                            LoadQuests.getGlobalQuests(),
+                                                            ((Player) sender).getPlayer());
+                                                } else
+                                                    sender.sendMessage(QuestsMessages.HOLO_CATEGORIZED_ENABLED.toString());
+                                                break;
+                                            case "easy":
+                                                if (LoadQuests.getEasyQuests().size() != 0) {
+                                                    HolographicDisplaysHook.createHologram(index,
+                                                            LoadQuests.getEasyQuests(),
+                                                            ((Player) sender).getPlayer());
+                                                } else
+                                                    sender.sendMessage(QuestsMessages.HOLO_CATEGORIZED_DISABLED.toString());
+                                                break;
+                                            case "medium":
+                                                if (LoadQuests.getMediumQuests().size() != 0) {
+                                                    HolographicDisplaysHook.createHologram(index,
+                                                            LoadQuests.getMediumQuests(),
+                                                            ((Player) sender).getPlayer());
+                                                } else
+                                                    sender.sendMessage(QuestsMessages.HOLO_CATEGORIZED_DISABLED.toString());
+                                                break;
+                                            case "hard":
+                                                if (LoadQuests.getHardQuests().size() != 0) {
+                                                    HolographicDisplaysHook.createHologram(index,
+                                                            LoadQuests.getHardQuests(),
+                                                            ((Player) sender).getPlayer());
+                                                } else
+                                                    sender.sendMessage(QuestsMessages.HOLO_CATEGORIZED_DISABLED.toString());
+                                                break;
+                                            default:
+                                                sender.sendMessage(QuestsMessages.INVALID_CATEGORY.toString());
+                                                break;
+                                        }
+                                        break;
                                     } else sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
+                                } else if (args.length == 3 && args[1].equalsIgnoreCase("delete")) {
+                                    int index;
+                                    try {
+                                        index = Integer.parseInt(args[2]);
+                                    } catch (Exception e) {
+                                        sender.sendMessage(QuestsMessages.INVALID_QUEST_INDEX.toString());
+                                        return true;
+                                    }
+                                    if (HologramsManager.deleteHologram(index)) {
+                                        sender.sendMessage(QuestsMessages.HOLO_DELETED.toString());
+                                    } else sender.sendMessage(QuestsMessages.HOLO_INVALID_INDEX.toString());
                                 } else sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
-                            } else sender.sendMessage(QuestsMessages.PLAYER_ONLY.toString());
-                            break;
-                        default:
-                            sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
-                            break;
-                    }
-                } else sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
-            } else sender.sendMessage(QuestsMessages.NO_PERMISSION.toString());
-        }
+                            } else sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
+                        } else sender.sendMessage(QuestsMessages.PLAYER_ONLY.toString());
+                        break;
+                    default:
+                        sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
+                        break;
+                }
+            } else sender.sendMessage(QuestsMessages.ADMIN_HELP.toString());
+        } else sender.sendMessage(QuestsMessages.NO_PERMISSION.toString());
         return false;
     }
 }

--- a/src/main/java/com/ordwen/odailyquests/commands/PlayerCommands.java
+++ b/src/main/java/com/ordwen/odailyquests/commands/PlayerCommands.java
@@ -25,68 +25,70 @@ public class PlayerCommands implements CommandExecutor {
     }
 
     @Override
-    public boolean onCommand(@NotNull CommandSender sender, Command command, @NotNull String label, @NotNull String[] args) {
-        if (command.getName().equalsIgnoreCase("quests")) {
-            if (sender instanceof Player) {
-                if (sender.hasPermission(QuestsPermissions.QUEST_USE.getPermission())) {
-                    if (args.length >= 1) {
-                        switch (args[0]) {
-                            case "show":
-                                if (sender.hasPermission(QuestsPermissions.QUEST_SHOW.getPermission())) {
-                                    if (args.length == 2) {
-                                        switch (args[1]) {
-                                            case "global":
-                                                if (configurationFiles.getConfigFile().getInt("quests_mode") != 1) {
-                                                    sender.sendMessage(QuestsMessages.CATEGORIZED_ENABLED.toString());
-                                                } else if (sender.hasPermission(QuestsPermissions.QUESTS_SHOW_GLOBAL.getPermission())) {
-                                                    ((Player) sender).openInventory(InterfacesManager.getGlobalQuestsInterface().getGlobalQuestsInterfaceFirstPage());
-                                                } else sender.sendMessage(QuestsMessages.NO_PERMISSION_CATEGORY.toString());
-                                                break;
-                                            case "easy":
-                                                if (configurationFiles.getConfigFile().getInt("quests_mode") != 2) {
-                                                    sender.sendMessage(QuestsMessages.CATEGORIZED_DISABLED.toString());
-                                                } else {
-                                                    if (sender.hasPermission(QuestsPermissions.QUESTS_SHOW_EASY.getPermission())) {
-                                                        ((Player) sender).openInventory(InterfacesManager.getCategorizedQuestsInterfaces().getEasyQuestsInterfaceFirstPage());
-                                                    } else sender.sendMessage(QuestsMessages.NO_PERMISSION_CATEGORY.toString());
-                                                }
-                                                break;
-                                            case "medium":
-                                                if (configurationFiles.getConfigFile().getInt("quests_mode") != 2) {
-                                                    sender.sendMessage(QuestsMessages.CATEGORIZED_DISABLED.toString());
-                                                } else {
-                                                    if (sender.hasPermission(QuestsPermissions.QUESTS_SHOW_MEDIUM.getPermission())) {
-                                                        ((Player) sender).openInventory(InterfacesManager.getCategorizedQuestsInterfaces().getMediumQuestsInterfaceFirstPage());
-                                                    } else sender.sendMessage(QuestsMessages.NO_PERMISSION_CATEGORY.toString());
-                                                }
-                                                break;
-                                            case "hard":
-                                                if (configurationFiles.getConfigFile().getInt("quests_mode") != 2) {
-                                                    sender.sendMessage(QuestsMessages.CATEGORIZED_DISABLED.toString());
-                                                } else {
-                                                    if (sender.hasPermission(QuestsPermissions.QUESTS_SHOW_HARD.getPermission())) {
-                                                        ((Player) sender).openInventory(InterfacesManager.getCategorizedQuestsInterfaces().getHardQuestsInterfaceFirstPage());
-                                                    } else sender.sendMessage(QuestsMessages.NO_PERMISSION_CATEGORY.toString());
-                                                }
-                                                break;
-                                            default:
-                                                sender.sendMessage(QuestsMessages.INVALID_CATEGORY.toString());
-                                                break;
-                                        }
-                                    } else sender.sendMessage(QuestsMessages.PLAYER_HELP.toString());
-                                } else sender.sendMessage(QuestsMessages.NO_PERMISSION.toString());
-                                break;
-                            case "me":
-                                ((Player) sender).openInventory(PlayerQuestsInterface.getPlayerQuestsInterface(sender.getName()));
-                                break;
-                            case "help":
-                            default:
-                                sender.sendMessage(QuestsMessages.PLAYER_HELP.toString());
-                                break;
-                        }
-                    } else ((Player) sender).openInventory(PlayerQuestsInterface.getPlayerQuestsInterface(sender.getName()));
-                } else sender.sendMessage(QuestsMessages.NO_PERMISSION.toString());
-            }
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (sender instanceof Player) {
+            if (sender.hasPermission(QuestsPermissions.QUEST_USE.getPermission())) {
+                if (args.length >= 1) {
+                    switch (args[0]) {
+                        case "show":
+                            if (sender.hasPermission(QuestsPermissions.QUEST_SHOW.getPermission())) {
+                                if (args.length == 2) {
+                                    switch (args[1]) {
+                                        case "global":
+                                            if (configurationFiles.getConfigFile().getInt("quests_mode") != 1) {
+                                                sender.sendMessage(QuestsMessages.CATEGORIZED_ENABLED.toString());
+                                            } else if (sender.hasPermission(QuestsPermissions.QUESTS_SHOW_GLOBAL.getPermission())) {
+                                                ((Player) sender).openInventory(InterfacesManager.getGlobalQuestsInterface().getGlobalQuestsInterfaceFirstPage());
+                                            } else sender.sendMessage(QuestsMessages.NO_PERMISSION_CATEGORY.toString());
+                                            break;
+                                        case "easy":
+                                            if (configurationFiles.getConfigFile().getInt("quests_mode") != 2) {
+                                                sender.sendMessage(QuestsMessages.CATEGORIZED_DISABLED.toString());
+                                            } else {
+                                                if (sender.hasPermission(QuestsPermissions.QUESTS_SHOW_EASY.getPermission())) {
+                                                    ((Player) sender).openInventory(InterfacesManager.getCategorizedQuestsInterfaces().getEasyQuestsInterfaceFirstPage());
+                                                } else
+                                                    sender.sendMessage(QuestsMessages.NO_PERMISSION_CATEGORY.toString());
+                                            }
+                                            break;
+                                        case "medium":
+                                            if (configurationFiles.getConfigFile().getInt("quests_mode") != 2) {
+                                                sender.sendMessage(QuestsMessages.CATEGORIZED_DISABLED.toString());
+                                            } else {
+                                                if (sender.hasPermission(QuestsPermissions.QUESTS_SHOW_MEDIUM.getPermission())) {
+                                                    ((Player) sender).openInventory(InterfacesManager.getCategorizedQuestsInterfaces().getMediumQuestsInterfaceFirstPage());
+                                                } else
+                                                    sender.sendMessage(QuestsMessages.NO_PERMISSION_CATEGORY.toString());
+                                            }
+                                            break;
+                                        case "hard":
+                                            if (configurationFiles.getConfigFile().getInt("quests_mode") != 2) {
+                                                sender.sendMessage(QuestsMessages.CATEGORIZED_DISABLED.toString());
+                                            } else {
+                                                if (sender.hasPermission(QuestsPermissions.QUESTS_SHOW_HARD.getPermission())) {
+                                                    ((Player) sender).openInventory(InterfacesManager.getCategorizedQuestsInterfaces().getHardQuestsInterfaceFirstPage());
+                                                } else
+                                                    sender.sendMessage(QuestsMessages.NO_PERMISSION_CATEGORY.toString());
+                                            }
+                                            break;
+                                        default:
+                                            sender.sendMessage(QuestsMessages.INVALID_CATEGORY.toString());
+                                            break;
+                                    }
+                                } else sender.sendMessage(QuestsMessages.PLAYER_HELP.toString());
+                            } else sender.sendMessage(QuestsMessages.NO_PERMISSION.toString());
+                            break;
+                        case "me":
+                            ((Player) sender).openInventory(PlayerQuestsInterface.getPlayerQuestsInterface(sender.getName()));
+                            break;
+                        case "help":
+                        default:
+                            sender.sendMessage(QuestsMessages.PLAYER_HELP.toString());
+                            break;
+                    }
+                } else
+                    ((Player) sender).openInventory(PlayerQuestsInterface.getPlayerQuestsInterface(sender.getName()));
+            } else sender.sendMessage(QuestsMessages.NO_PERMISSION.toString());
         }
         return false;
     }

--- a/src/main/java/com/ordwen/odailyquests/quests/player/progression/Utils.java
+++ b/src/main/java/com/ordwen/odailyquests/quests/player/progression/Utils.java
@@ -36,7 +36,7 @@ public class Utils {
             switch (temporalityMode) {
                 case 1:
                     currentCal.setTimeInMillis(System.currentTimeMillis());
-                    return oldCal.get(Calendar.DATE) < currentCal.get(Calendar.DATE);
+                    return oldCal.get(Calendar.DAY_OF_YEAR) < currentCal.get(Calendar.DAY_OF_YEAR);
                 case 2:
                     currentCal.setTimeInMillis(System.currentTimeMillis());
                     long diffW = TimeUnit.DAYS.convert(currentCal.getTimeInMillis() - oldCal.getTimeInMillis(), TimeUnit.MILLISECONDS);

--- a/src/main/java/com/ordwen/odailyquests/tools/TimerTask.java
+++ b/src/main/java/com/ordwen/odailyquests/tools/TimerTask.java
@@ -19,6 +19,10 @@ public class TimerTask {
 
     ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
+    /**
+     * Set a runnable to reload quests at midnight.
+     * @param start date and time to start the task.
+     */
     public TimerTask(LocalDateTime start) {
 
         Runnable runnable = () -> {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,14 +8,18 @@ description: Add more objectives and dynamize your server !
 website: https://www.spigotmc.org/resources/odailyquests-daily-quests-plugin-1-16-1-18.100990/
 softdepend: [Vault, TokenManager, Citizens, PlaceholderAPI, PlayerPoints, MythicMobs, EliteMobs, HolographicDisplays]
 commands:
-  quests:
+  dquests:
     description: default player command
     aliases:
-      - quest
-  questsadmin:
+      - dailyquests
+      - dq
+      - quests
+  dqadmin:
     description: admin command
     aliases:
-      - questadmin
+      - dailyquestsadmin
+      - dquestsadmin
+      - dqa
       - qadmin
 
 


### PR DESCRIPTION
- Fixed a bug that prevented quests from being renewed once the next month was reached.
- Fixed an omission that caused all quests to be renewed at midnight every day, without taking into account the timestamp or temporality mode.

Commands
To avoid conflicts with other plugins, the main commands of the plugin are now /dquests (like /dailyquests), and /dqadmin (like /dailyquestsadmin).
The /quests and /questsadmin commands are now aliases, so you can still use them. They will simply not take priority if another plugin using these commands is installed on your server.